### PR TITLE
Bump BrightFutures

### DIFF
--- a/Spine.podspec
+++ b/Spine.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'SwiftyJSON', '>= 2.1.3'
-  s.dependency 'BrightFutures', '1.0.0-beta.3'
+  s.dependency 'BrightFutures', '1.0.1'
 end


### PR DESCRIPTION
It appears that version 1.0.0-beta.3 does not compile anymore, so the fix is to switch to 1.0.1 and maybe to 2.0.0 later.