### PR TITLE
Adds JSONAPI version 1 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Spine
 =====
-Spine is a Swift library for working with APIs that adhere to the [jsonapi.org](http://jsonapi.org) standard. It supports mapping to custom model classes, fetching, advanced querying, linking and persisting
+Spine is a Swift library for working with APIs that adhere to the [jsonapi.org](http://jsonapi.org) standard. It supports mapping to custom model classes, fetching, advanced querying, linking and persisting.
+
+The `master` branch currently supports the spec of JSONAPI v1.
 
 Installation
 ============


### PR DESCRIPTION
I'm learning iOS and I want to use this, but it was hard to figure out what version of the jsonapi format it is using. I had to check the tests to match the format to conclude whether to use this lib or not. I maintain other jsonapi libs (Ruby, JS) since before RC1 and the flux since then up to v1 was really confusing for newcomers.

This line on the README should help other people I believe.