### PR TITLE
Adds tests for resource creation

### DIFF
--- a/Spine/Networking.swift
+++ b/Spine/Networking.swift
@@ -84,9 +84,9 @@ public class URLSessionClient: _HTTPClientProtocol {
 	private func performRequest(request: NSURLRequest, callback: HTTPClientCallback) {
 		let task = urlSession.dataTaskWithRequest(request) { data, response, error in
 			let response = (response as? NSHTTPURLResponse)
-			
+
 			// Network error
-			if let error = error {
+			if let statusCode = response?.statusCode where 400 ... 599 ~= statusCode {
 				Spine.logError(.Networking, "\(request.URL) - \(error.localizedDescription)")
 				
 			// Success

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -211,12 +211,14 @@ class SaveOperation: Operation {
 		Spine.logInfo(.Spine, "Saving resource \(resource) using URL: \(request.URL)")
 		
 		HTTPClient.request(request.method, URL: request.URL, payload: request.payload) { statusCode, responseData, networkError in
-			if let networkError = networkError {
-				self.result = Failable(networkError)
-				self.state = .Finished
-				return
-			}
-			
+
+            if 400 ... 599 ~= statusCode! {
+                let error = NSError(domain: "networkError", code: statusCode!, userInfo: nil)
+                self.result = Failable(error)
+                self.state = .Finished
+                return
+            }
+
 			// Map the response back onto the resource
 			if let data = responseData {
 				self.serializer.deserializeData(data, mappingTargets: [self.resource])

--- a/SpineTests/SpineTests.swift
+++ b/SpineTests/SpineTests.swift
@@ -367,6 +367,30 @@ class PersistingTests: SpineTests {
 	// MARK: Save
 	
 	//TODO
+
+    func testCreateResourceWithAPIError() {
+
+        HTTPClient.handler = { (request: NSURLRequest, payload: NSData?) -> (responseData: NSData, statusCode: Int, error: NSError?) in
+            XCTAssertEqual(request.URL!, NSURL(string:"http://example.com/foos")!, "Request URL not as expected.")
+            XCTAssertEqual(request.HTTPMethod!, "POST", "Expected HTTP method to be 'POST'.")
+            var responseData = "{}".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+            return (responseData: responseData!, statusCode: 400, error: nil)
+        }
+
+        let foo = Foo()
+        let expectation = expectationWithDescription("testCreateResource")
+
+        spine.save(foo).onSuccess { _ in
+            expectation.fulfill()
+            XCTFail("A 400 error code should not be considered successful.")
+            }.onFailure { error in
+                expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10) { error in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
 }
 
 


### PR DESCRIPTION
Just adds some tests. It's weird because in my app, `400` errors are being routed to `onSuccess` block. This test proves the lib is working fine.