### PR TITLE
Relies on statusCode to figure out whether a request failed

### DIFF
--- a/Spine/Networking.swift
+++ b/Spine/Networking.swift
@@ -84,7 +84,7 @@ public class URLSessionClient: _HTTPClientProtocol {
 	private func performRequest(request: NSURLRequest, callback: HTTPClientCallback) {
 		let task = urlSession.dataTaskWithRequest(request) { data, response, error in
 			let response = (response as? NSHTTPURLResponse)
-			
+
 			// Network error
 			if let error = error {
 				Spine.logError(.Networking, "\(request.URL) - \(error.localizedDescription)")

--- a/SpineTests/SpineTests.swift
+++ b/SpineTests/SpineTests.swift
@@ -367,6 +367,30 @@ class PersistingTests: SpineTests {
 	// MARK: Save
 	
 	//TODO
+
+    func testCreateResourceWithAPIError() {
+
+        HTTPClient.handler = { (request: NSURLRequest, payload: NSData?) -> (responseData: NSData, statusCode: Int, error: NSError?) in
+            XCTAssertEqual(request.URL!, NSURL(string:"http://example.com/foos")!, "Request URL not as expected.")
+            XCTAssertEqual(request.HTTPMethod!, "POST", "Expected HTTP method to be 'POST'.")
+            var responseData = "{}".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+            return (responseData: responseData!, statusCode: 400, error: nil)
+        }
+
+        let foo = Foo()
+        let expectation = expectationWithDescription("testCreateResource")
+
+        spine.save(foo).onSuccess { _ in
+            expectation.fulfill()
+            XCTFail("A 400 error code should not be considered successful.")
+            }.onFailure { error in
+                expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10) { error in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
 }
 
 


### PR DESCRIPTION
This PR stops relying on NSURLSession.error and relies on the status code to figure whether a request failed or not. The reason is because in my app, `.error` is `nil` even when status code is `400`. That was preventing `.onFailure` to ever be triggered.

Running the tests after the change, nothing broke, so I suppose everything's fine. Plus, my app is now working :D