### PR TITLE
RelationshipOperation had no spine instance

### DIFF
--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -229,7 +229,8 @@ class SaveOperation: Operation {
 				return
 			} else {
 				let relationshipOperation = RelationshipOperation(resource: self.resource)
-				
+				relationshipOperation.spine = self.spine
+
 				relationshipOperation.completionBlock = {
 					if let error = relationshipOperation.result?.error {
 						self.result = Failable(error)


### PR DESCRIPTION
RelationshipOperation doesn't get an instance of the `spine` object, so it we can't work with relationships. I know it's likely not going to be merge right now because of the Swift2 rewrite and the lack of tests (writing tests proved to be really hard because we have none), but I need to keep this fix somewhere so I can get back to it in the future when the Swift2 rewrite is finished.