### PR TITLE
Relies on statusCode to figure out whether a request failed

### DIFF
--- a/Spine/Networking.swift
+++ b/Spine/Networking.swift
@@ -84,7 +84,7 @@ public class URLSessionClient: _HTTPClientProtocol {
 	private func performRequest(request: NSURLRequest, callback: HTTPClientCallback) {
 		let task = urlSession.dataTaskWithRequest(request) { data, response, error in
 			let response = (response as? NSHTTPURLResponse)
-			
+
 			// Network error
 			if let error = error {
 				Spine.logError(.Networking, "\(request.URL) - \(error.localizedDescription)")

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -211,35 +211,44 @@ class SaveOperation: Operation {
 		Spine.logInfo(.Spine, "Saving resource \(resource) using URL: \(request.URL)")
 		
 		HTTPClient.request(request.method, URL: request.URL, payload: request.payload) { statusCode, responseData, networkError in
-			if let networkError = networkError {
-				self.result = Failable(networkError)
-				self.state = .Finished
-				return
-			}
-			
-			// Map the response back onto the resource
-			if let data = responseData {
-				self.serializer.deserializeData(data, mappingTargets: [self.resource])
-			}
-			
-			// Separately update relationships if this is an existing resource
-			if self.isNewResource {
-				self.result = Failable()
-				self.state = .Finished
-				return
-			} else {
-				let relationshipOperation = RelationshipOperation(resource: self.resource)
-				relationshipOperation.spine = self.spine
 
-				relationshipOperation.completionBlock = {
-					if let error = relationshipOperation.result?.error {
-						self.result = Failable(error)
+			if let statusCode = statusCode {
+				if 200 ... 399 ~= statusCode {
+					// Map the response back onto the resource
+					if let data = responseData {
+						self.serializer.deserializeData(data, mappingTargets: [self.resource])
 					}
-					
-					self.state = .Finished
-				}
 
-				relationshipOperation.execute()
+					// Separately update relationships if this is an existing resource
+					if self.isNewResource {
+						self.result = Failable()
+						self.state = .Finished
+						return
+					} else {
+						let relationshipOperation = RelationshipOperation(resource: self.resource)
+						relationshipOperation.spine = self.spine
+
+						relationshipOperation.completionBlock = {
+							if let error = relationshipOperation.result?.error {
+								self.result = Failable(error)
+							}
+
+							self.state = .Finished
+						}
+
+						relationshipOperation.execute()
+					}
+				} else {
+					let error = NSError(domain: "networkError", code: statusCode, userInfo: nil)
+					self.result = Failable(error)
+					self.state = .Finished
+					return
+
+				}
+			} else {
+				self.result = Failable(networkError!)
+				self.state = .Finished
+				return
 			}
 		}
 	}

--- a/SpineTests/SpineTests.swift
+++ b/SpineTests/SpineTests.swift
@@ -367,6 +367,30 @@ class PersistingTests: SpineTests {
 	// MARK: Save
 	
 	//TODO
+
+    func testCreateResourceWithAPIError() {
+
+        HTTPClient.handler = { (request: NSURLRequest, payload: NSData?) -> (responseData: NSData, statusCode: Int, error: NSError?) in
+            XCTAssertEqual(request.URL!, NSURL(string:"http://example.com/foos")!, "Request URL not as expected.")
+            XCTAssertEqual(request.HTTPMethod!, "POST", "Expected HTTP method to be 'POST'.")
+            var responseData = "{}".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+            return (responseData: responseData!, statusCode: 400, error: nil)
+        }
+
+        let foo = Foo()
+        let expectation = expectationWithDescription("testCreateResource")
+
+        spine.save(foo).onSuccess { _ in
+            expectation.fulfill()
+            XCTFail("A 400 error code should not be considered successful.")
+            }.onFailure { error in
+                expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10) { error in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
 }
 
 


### PR DESCRIPTION
This PR stops relying on NSURLSession.error and relies on the status code to
figure whether a request failed or not. The reason is because in my app, 
`.error` is `nil` even when status code is `400`. That was preventing 
`.onFailure` to ever be triggered.

Running the tests after the change, nothing broke, so I suppose everything's
 fine. Plus, my app is now working :D