### PR TITLE
[swift-2.0] Changes the BrightFutures dep version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Thomvis/BrightFutures" "swift-2.0"
+github "Thomvis/BrightFutures" ~> 3.0
 github "SwiftyJSON/SwiftyJSON" ~> 2.3.0

--- a/Spine.podspec
+++ b/Spine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Spine'
-  s.version = '0.1'
+  s.version = '0.2'
   s.license = 'MIT'
   s.summary = 'A Swift library for interaction with a jsonapi.org API'
   s.homepage = 'https://github.com/wvteijlingen/Spine'
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'SwiftyJSON', '~> 2.3.0'
-  s.dependency 'BrightFutures', :git => 'https://github.com/Thomvis/BrightFutures.git', :branch => 'swift-2.0'
+  s.dependency 'BrightFutures', '~> 3.0'
 end


### PR DESCRIPTION
This should fix:

```
→ pod install
Updating local specs repositories
Analyzing dependencies
Pre-downloading: `Spine` from
`https://github.com/wvteijlingen/Spine.git`, branch `swift-2.0`, commit
`ca05706b8480655076a131a34d9cccb1aa0d975d`, tag `swift-2.0`
[!] Unable to find a specification for 'Spine'.

[!] Unable to load a podspec from `Spine.podspec`, skipping:

Pod::DSLError
```

Tested locally,

```
→ pod install
Updating local specs repositories
Analyzing dependencies
Downloading dependencies
Using Alamofire (1.3.0)
Using BrightFutures (3.0.0)
Using Result (0.6.0-beta.4)
Using Spine (0.2)
Using SwiftyJSON (2.3.0)
Generating Pods project
Integrating client project
Sending stats
Pod installation complete! There are 3 dependencies from the Podfile and 7 total pods installed.
```