### PR TITLE
Relationships Improvements

### DIFF
--- a/Spine/DeserializeOperation.swift
+++ b/Spine/DeserializeOperation.swift
@@ -222,13 +222,18 @@ class DeserializeOperation: NSOperation {
 	This method loops over all the relationships in the passed resource, maps the relationship name
 	to the key for the serialized form and invokes `extractToOneRelationship` or `extractToManyRelationship`.
 	It then sets the extracted ResourceRelationship on the resource.
+	It also sets `relationships` dictionary on parent resource containing the links to all related resources.
 	
 	- parameter serializedData: The data from which to extract the relationships.
 	- parameter resource:       The resource into which to extract the relationships.
 	*/
 	private func extractRelationships(serializedData: JSON, intoResource resource: Resource) {
+		resource.relationships = [String: [String: AnyObject]]()
+
 		for field in resource.fields {
 			let key = keyFormatter.format(field)
+			resource.relationships![field.name] = serializedData["relationships"][key].dictionaryObject
+
 			switch field {
 			case let toOne as ToOneRelationship:
 				if let linkedResource = extractToOneRelationship(serializedData, key: key, linkedType: toOne.linkedType.resourceType, resource: resource) {

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -24,17 +24,6 @@ private func errorFromStatusCode(statusCode: Int, additionalErrors: [NSError]? =
 	return NSError(domain: SpineServerErrorDomain, code: statusCode, userInfo: userInfo)
 }
 
-private func convertResourcesToLinkage(resources: [Resource]) -> [[String: String]] {
-	if resources.isEmpty {
-		return []
-	} else {
-		return resources.map { resource in
-			assert(resource.id != nil, "Attempt to convert resource without id to linkage. Only resources with ids can be converted to linkage.")
-			return [resource.resourceType: resource.id!]
-		}
-	}
-}
-
 // MARK: - Base operation
 
 /**
@@ -232,6 +221,7 @@ class SaveOperation: ConcurrentOperation {
 	/// Whether the resource is a new resource, or an existing resource.
 	private let isNewResource: Bool
 	
+	private var responseData: NSData?
 	private let relationshipOperationQueue = NSOperationQueue()
 	
 	init(resource: Resource, spine: Spine) {
@@ -292,11 +282,11 @@ class SaveOperation: ConcurrentOperation {
 					self.state = .Finished
 					return
 				}
-				
 			} else {
 				if let data = responseData where data.length > 0 {
 					do {
-						try self.serializer.deserializeData(data, mappingTargets: [self.resource])
+						try self.serializer.deserializeData(data, mappingTargets: nil)
+						self.responseData = data
 					} catch let error as NSError {
 						self.result = .Failure(error)
 						self.state = .Finished
@@ -311,6 +301,7 @@ class SaveOperation: ConcurrentOperation {
 			
 			// Separately update relationships if this is an existing resource
 			if self.isNewResource {
+				self.deserializeIntoResource()
 				self.result = Failable.Success()
 				self.state = .Finished
 			} else {
@@ -318,8 +309,14 @@ class SaveOperation: ConcurrentOperation {
 			}
 		}
 	}
-	
-	func updateRelationships() {
+
+	private func deserializeIntoResource() {
+		if responseData != nil {
+			try! self.serializer.deserializeData(responseData!, mappingTargets: [self.resource])
+		}
+	}
+
+	private func updateRelationships() {
 		self.relationshipOperationQueue.addObserver(self, forKeyPath: "operations", options: NSKeyValueObservingOptions(), context: nil)
 		
 		let completionHandler: (result: Failable<Void>) -> Void = { result in
@@ -332,16 +329,22 @@ class SaveOperation: ConcurrentOperation {
 		for field in resource.fields {
 			switch field {
 			case let toOne as ToOneRelationship:
-				let operation = RelationshipReplaceOperation(resource: resource, relationship: toOne, spine: spine)
-				operation.completionBlock = { [unowned operation] in completionHandler(result: operation.result!) }
-				relationshipOperationQueue.addOperation(operation)
-				
+				if resource.valueForField(toOne.name) != nil {
+					let operation = RelationshipToOneUpdateOperation(resource: resource, relationship: toOne, spine: spine)
+					operation.completionBlock = { [unowned operation] in completionHandler(result: operation.result!) }
+					relationshipOperationQueue.addOperation(operation)
+				} else {
+					let operation = RelationshipToOneRemoveOperation(resource: resource, relationship: toOne, spine: spine)
+					operation.completionBlock = { [unowned operation] in completionHandler(result: operation.result!) }
+					relationshipOperationQueue.addOperation(operation)
+				}
+
 			case let toMany as ToManyRelationship:
-				let addOperation = RelationshipAddOperation(resource: resource, relationship: toMany, spine: spine)
+				let addOperation = RelationshipToManyAddOperation(resource: resource, relationship: toMany, spine: spine)
 				addOperation.completionBlock = { [unowned addOperation] in completionHandler(result: addOperation.result!) }
 				relationshipOperationQueue.addOperation(addOperation)
 				
-				let removeOperation = RelationshipRemoveOperation(resource: resource, relationship: toMany, spine: spine)
+				let removeOperation = RelationshipToManyRemoveOperation(resource: resource, relationship: toMany, spine: spine)
 				removeOperation.completionBlock = { [unowned removeOperation] in completionHandler(result: removeOperation.result!) }
 				relationshipOperationQueue.addOperation(removeOperation)
 			default: ()
@@ -356,6 +359,7 @@ class SaveOperation: ConcurrentOperation {
 		}
 		
 		if queue.operationCount == 0 {
+			self.deserializeIntoResource()
 			self.result = Failable.Success()
 			self.state = .Finished
 		}
@@ -390,11 +394,20 @@ private class RelationshipOperation: ConcurrentOperation {
 			self.result = .Failure(errorFromStatusCode(statusCode!))
 		}
 	}
+
+	private func resourceLinkage(resource: Resource) -> [String: String]! {
+		assert(resource.id != nil, "Attempt to convert resource without id to linkage. Only resources with ids can be converted to linkage.")
+
+		return ["type": resource.resourceType, "id": resource.id!]
+	}
 }
 
-private class RelationshipReplaceOperation: RelationshipOperation {
+private class RelationshipToOneOperation: RelationshipOperation {
 	let resource: Resource
 	let relationship: ToOneRelationship
+	var relatedResource: Resource! {
+		return resource.valueForField(relationship.name) as! Resource
+	}
 
 	init(resource: Resource, relationship: ToOneRelationship, spine: Spine) {
 		self.resource = resource
@@ -403,73 +416,77 @@ private class RelationshipReplaceOperation: RelationshipOperation {
 		self.spine = spine
 	}
 	
-	override func execute() {
-		let relatedResource = resource.valueForField(relationship.name) as! Resource
-		let linkage = convertResourcesToLinkage([relatedResource])
-		
-		if let jsonPayload = try? NSJSONSerialization.dataWithJSONObject(["data": linkage], options: NSJSONWritingOptions(rawValue: 0)) {
-			if let links = resource.relationships![relationship.name]?["links"] as? NSDictionary {
-				let URL = NSURL(string: links["self"] as! String)
-				networkClient.request("PATCH", URL: URL!, payload: jsonPayload, callback: handleNetworkResponse)
-			}
+	private func execute(httpMethod: String, payload: NSData?) {
+		let links = resource.relationships![relationship.name]?["links"] as? NSDictionary
+
+		guard links?["self"] != nil else {
+			self.result = Failable()
+			self.state = .Finished
+			return
 		}
+		
+		let URL = NSURL(string: links!["self"] as! String)
+		networkClient.request(httpMethod, URL: URL!, payload: payload, callback: handleNetworkResponse)
+	}
+
+	private func payload() -> NSData! {
+		return try! NSJSONSerialization.dataWithJSONObject(["data": resourceLinkage(relatedResource)], options: NSJSONWritingOptions(rawValue: 0))
 	}
 }
 
-private class RelationshipAddOperation: RelationshipOperation {
+private class RelationshipToOneUpdateOperation: RelationshipToOneOperation {
+	override func execute() {
+		super.execute("PATCH", payload: payload())
+	}
+}
+
+private class RelationshipToOneRemoveOperation: RelationshipToOneOperation {
+	override func execute() {
+		super.execute("DELETE", payload: nil)
+	}
+}
+
+private class RelationshipToManyOperation: RelationshipOperation {
 	let resource: Resource
 	let relationship: ToManyRelationship
-	
+	var resourceCollection: LinkedResourceCollection {
+		return resource.valueForField(relationship.name) as! LinkedResourceCollection
+	}
+
 	init(resource: Resource, relationship: ToManyRelationship, spine: Spine) {
 		self.resource = resource
 		self.relationship = relationship
 		super.init()
 		self.spine = spine
 	}
-	
-	override func execute() {
-		let resourceCollection = resource.valueForField(relationship.name) as! LinkedResourceCollection
-		let relatedResources = resourceCollection.addedResources
-		
+
+	private func execute(httpMethod: String, relatedResources: [Resource]) {
 		guard !relatedResources.isEmpty else {
 			self.result = Failable()
 			self.state = .Finished
 			return
 		}
-		
-		let linkage = convertResourcesToLinkage(relatedResources)
-		
-		if let jsonPayload = try? NSJSONSerialization.dataWithJSONObject(["data": linkage], options: NSJSONWritingOptions(rawValue: 0)) {
-			networkClient.request("POST", URL: resourceCollection.linkURL!, payload: jsonPayload, callback: handleNetworkResponse)
-		}
+
+		networkClient.request(httpMethod, URL: resourceCollection.linkURL!, payload: payload(relatedResources), callback: handleNetworkResponse)
+	}
+
+	private func payload(relatedResources: [Resource]) -> NSData {
+		return try! NSJSONSerialization.dataWithJSONObject(["data": linkage(relatedResources)], options: NSJSONWritingOptions(rawValue: 0))
+	}
+
+	private func linkage(relatedResources: [Resource]) -> [[String: String]] {
+		return relatedResources.map { resourceLinkage($0) }
 	}
 }
 
-private class RelationshipRemoveOperation: RelationshipOperation {
-	let resource: Resource
-	let relationship: ToManyRelationship
-	
-	init(resource: Resource, relationship: ToManyRelationship, spine: Spine) {
-		self.resource = resource
-		self.relationship = relationship
-		super.init()
-		self.spine = spine
-	}
-	
+private class RelationshipToManyAddOperation: RelationshipToManyOperation {
 	override func execute() {
-		let resourceCollection = resource.valueForField(relationship.name) as! LinkedResourceCollection
-		let relatedResources = resourceCollection.removedResources
-		
-		guard !relatedResources.isEmpty else {
-			self.result = Failable()
-			self.state = .Finished
-			return
-		}
+		super.execute("POST", relatedResources: resourceCollection.addedResources)
+	}
+}
 
-		let linkage = convertResourcesToLinkage(relatedResources)
-
-		if let jsonPayload = try? NSJSONSerialization.dataWithJSONObject(["data": linkage], options: NSJSONWritingOptions(rawValue: 0)) {
-			networkClient.request("DELETE", URL: resourceCollection.linkURL!, payload: jsonPayload, callback: handleNetworkResponse)
-		}
+private class RelationshipToManyRemoveOperation: RelationshipToManyOperation {
+	override func execute() {
+		super.execute("DELETE", relatedResources: resourceCollection.removedResources)
 	}
 }

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -408,8 +408,10 @@ private class RelationshipReplaceOperation: RelationshipOperation {
 		let linkage = convertResourcesToLinkage([relatedResource])
 		
 		if let jsonPayload = try? NSJSONSerialization.dataWithJSONObject(["data": linkage], options: NSJSONWritingOptions(rawValue: 0)) {
-			let URL = router.URLForRelationship(relationship, ofResource: resource)
-			networkClient.request("PATCH", URL: URL, payload: jsonPayload, callback: handleNetworkResponse)
+			if let links = resource.relationships![relationship.name]?["links"] as? NSDictionary {
+				let URL = NSURL(string: links["self"] as! String)
+				networkClient.request("PATCH", URL: URL!, payload: jsonPayload, callback: handleNetworkResponse)
+			}
 		}
 	}
 }
@@ -438,8 +440,7 @@ private class RelationshipAddOperation: RelationshipOperation {
 		let linkage = convertResourcesToLinkage(relatedResources)
 		
 		if let jsonPayload = try? NSJSONSerialization.dataWithJSONObject(["data": linkage], options: NSJSONWritingOptions(rawValue: 0)) {
-			let URL = router.URLForRelationship(relationship, ofResource: self.resource)
-			networkClient.request("POST", URL: URL, payload: jsonPayload, callback: handleNetworkResponse)
+			networkClient.request("POST", URL: resourceCollection.linkURL!, payload: jsonPayload, callback: handleNetworkResponse)
 		}
 	}
 }
@@ -464,8 +465,7 @@ private class RelationshipRemoveOperation: RelationshipOperation {
 			self.state = .Finished
 			return
 		}
-		
-		let URL = router.URLForRelationship(relationship, ofResource: self.resource)
-		networkClient.request("DELETE", URL: URL, callback: handleNetworkResponse)
+
+		networkClient.request("DELETE", URL: resourceCollection.linkURL!, callback: handleNetworkResponse)
 	}
 }

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -458,7 +458,7 @@ private class RelationshipRemoveOperation: RelationshipOperation {
 	
 	override func execute() {
 		let resourceCollection = resource.valueForField(relationship.name) as! LinkedResourceCollection
-		let relatedResources = resourceCollection.addedResources
+		let relatedResources = resourceCollection.removedResources
 		
 		guard !relatedResources.isEmpty else {
 			self.result = Failable()
@@ -466,6 +466,10 @@ private class RelationshipRemoveOperation: RelationshipOperation {
 			return
 		}
 
-		networkClient.request("DELETE", URL: resourceCollection.linkURL!, callback: handleNetworkResponse)
+		let linkage = convertResourcesToLinkage(relatedResources)
+
+		if let jsonPayload = try? NSJSONSerialization.dataWithJSONObject(["data": linkage], options: NSJSONWritingOptions(rawValue: 0)) {
+			networkClient.request("DELETE", URL: resourceCollection.linkURL!, payload: jsonPayload, callback: handleNetworkResponse)
+		}
 	}
 }

--- a/Spine/Resource.swift
+++ b/Spine/Resource.swift
@@ -91,6 +91,9 @@ public class Resource: NSObject, NSCoding {
 	/// The metadata for this resource.
 	public var meta: [String: AnyObject]?
 	
+	/// The relationships dictionary for this resource.
+	public var relationships: [String: [String: AnyObject]]?
+	
 	public required override init() {
 		super.init()
 	}

--- a/Spine/Routing.swift
+++ b/Spine/Routing.swift
@@ -27,16 +27,6 @@ public protocol Router: class {
 	func URLForResourceType(type: ResourceType) -> NSURL
 	
 	/**
-	Returns an NSURL that points to a relationship of a resource.
-	
-	- parameter relationship: The relationship to get the URL for.
-	- parameter resource:     The resource that contains the relationship.
-	
-	- returns: The NSURL.
-	*/
-	func URLForRelationship<T: Resource>(relationship: Relationship, ofResource resource: T) -> NSURL
-	
-	/**
 	Returns an NSURL that represents the given query.
 	
 	- parameter query: The query to turn into an NSURL.
@@ -69,12 +59,6 @@ public class JSONAPIRouter: Router {
 		return baseURL.URLByAppendingPathComponent(type)
 	}
 	
-	public func URLForRelationship<T: Resource>(relationship: Relationship, ofResource resource: T) -> NSURL {
-		let resourceURL = resource.URL ?? URLForResourceType(resource.resourceType).URLByAppendingPathComponent("/\(resource.id!)")
-		let key = keyFormatter.format(relationship)
-		return resourceURL.URLByAppendingPathComponent("/links/\(key)")
-	}
-
 	public func URLForQuery<T: Resource>(query: Query<T>) -> NSURL {
 		var URL: NSURL!
 		var preBuiltURL = false

--- a/SpineTests/Fixtures/MultipleFoos.json
+++ b/SpineTests/Fixtures/MultipleFoos.json
@@ -16,13 +16,13 @@
 		"relationships": {
 			"to-one-attribute": {
 				"links": {
-					"self": "http://example.com/foos/1/links/toOneAttribute",
+					"self": "http://example.com/foos/1/relationships/to-one-attribute",
 					"related": "http://example.com/bars/10"
 				}
 			},
 			"to-many-attribute": {
 				"links": {
-					"self": "http://example.com/foos/1/links/toManyAttribute",
+					"self": "http://example.com/foos/1/relationships/to-many-attribute",
 					"related": "http://example.com/bars/11,12"
 				}
 			}
@@ -44,13 +44,13 @@
 		"relationships": {
 			"to-one-attribute": {
 				"links": {
-					"self": "http://example.com/foos/1/links/toOneAttribute",
+					"self": "http://example.com/foos/1/relationships/to-one-attribute",
 					"related": "http://example.com/bars/10"
 				}
 			},
 			"to-many-attribute": {
 				"links": {
-					"self": "http://example.com/foos/1/links/toManyAttribute",
+					"self": "http://example.com/foos/1/relationships/to-many-attribute",
 					"related": "http://example.com/bars/11,12"
 				}
 			}

--- a/SpineTests/Fixtures/SingleFoo.json
+++ b/SpineTests/Fixtures/SingleFoo.json
@@ -16,14 +16,14 @@
 		"relationships": {
 			"to-one-attribute": {
 				"links": {
-					"self": "http://example.com/foos/1/links/toOneAttribute",
+					"self": "http://example.com/foos/1/relationships/to-one-attribute",
 					"related": "http://example.com/bars/10"
 				},
 				"data": { "type": "bars", "id": "10" }
 			},
 			"to-many-attribute": {
 				"links": {
-					"self": "http://example.com/foos/1/links/toManyAttribute",
+					"self": "http://example.com/foos/1/relationships/to-many-attribute",
 					"related": "http://example.com/bars/11,12"
 				},
 				"data": [

--- a/SpineTests/Fixtures/SingleFooIncludingBars.json
+++ b/SpineTests/Fixtures/SingleFooIncludingBars.json
@@ -16,14 +16,14 @@
 		"relationships": {
 			"to-one-attribute": {
 				"links": {
-					"self": "http://example.com/foos/1/links/toOneAttribute",
+					"self": "http://example.com/foos/1/relationships/to-one-attribute",
 					"related": "http://example.com/bars/10"
 				},
 				"data": { "type": "bars", "id": "10" }
 			},
 			"to-many-attribute": {
 				"links": {
-					"self": "http://example.com/foos/1/links/toManyAttribute",
+					"self": "http://example.com/foos/1/relationships/to-many-attribute",
 					"related": "http://example.com/bars/11,12"
 				},
 				"data": [

--- a/SpineTests/RoutingTests.swift
+++ b/SpineTests/RoutingTests.swift
@@ -17,15 +17,6 @@ class RoutingTests: XCTestCase {
 		let expectedURL = NSURL(string: "http://example.com/foos")!
 		XCTAssertEqual(URL, expectedURL, "URL not as expected.")
 	}
-	
-	func testURLForRelationship() {
-		let resource = Foo(id: "1")
-		let relationship = ToOneRelationship(Bar).serializeAs("relationship")
-		let URL = spine.router.URLForRelationship(relationship, ofResource: resource)
-		
-		let expectedURL = NSURL(string: "http://example.com/foos/1/links/relationship")!
-		XCTAssertEqual(URL, expectedURL, "URL not as expected.")
-	}
 
 	func testURLForQuery() {
 		var query = Query(resourceType: Foo.self, resourceIDs: ["1", "2"])

--- a/SpineTests/SerializingTests.swift
+++ b/SpineTests/SerializingTests.swift
@@ -168,7 +168,7 @@ class DeserializingTests: SerializerTests {
 					// To one link
 					XCTAssertNotNil(foo.toOneAttribute, "Expected linked resource to be not nil.")
 					let bar = foo.toOneAttribute!
-					XCTAssertEqual(bar.URL!.absoluteString, resourceJSON["relationships"]["to-one-attribute"]["links"]["related"].stringValue, "Deserialized link URL is not equal.")
+					XCTAssertEqual(bar.URL!.absoluteString, resourceJSON["relationships"]["to-one-attribute"]["links"]["related"].stringValue, "Deserialized resource URL is not equal.")
 					XCTAssertFalse(bar.isLoaded, "Expected isLoaded to be false.")
 					
 					// To many link
@@ -209,7 +209,7 @@ class DeserializingTests: SerializerTests {
 					
 					XCTAssertNotNil(bar.URL, "Expected URL to not be nil.")
 					if let URL = bar.URL {
-						XCTAssertEqual(URL, NSURL(string: json["data"]["relationships"]["to-one-attribute"]["links"]["related"].stringValue)!, "Deserialized link URL is not equal.")
+						XCTAssertEqual(URL, NSURL(string: json["data"]["relationships"]["to-one-attribute"]["links"]["related"].stringValue)!, "Deserialized resource URL is not equal.")
 					}
 					
 					XCTAssertNotNil(bar.id, "Expected id to not be nil.")

--- a/SpineTests/SpineTests.swift
+++ b/SpineTests/SpineTests.swift
@@ -395,15 +395,11 @@ class SaveTests: SpineTests {
 
 	func testItShouldPATCHWhenUpdatingAResource() {
 		var resourcePatched = false
-		var toOnePatched = false
 		
 		HTTPClient.handler = { request, payload in
 			XCTAssertEqual(request.HTTPMethod!, "PATCH", "HTTP method not as expected.")
-			if(request.URL! == NSURL(string:"http://example.com/foos/1")!) {
+			if(request.URL! == NSURL(string: "http://example.com/foos/1")!) {
 				resourcePatched = true
-			}
-			if(request.URL! == NSURL(string:"http://example.com/foos/1/relationships/to-one-attribute")!) {
-				toOnePatched = true
 			}
 			return (responseData: self.fixture.data, statusCode: 201, error: nil)
 		}
@@ -415,7 +411,6 @@ class SaveTests: SpineTests {
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
 			XCTAssertTrue(resourcePatched)
-			XCTAssertTrue(toOnePatched)
 		}
 	}
 	
@@ -444,6 +439,128 @@ class SaveTests: SpineTests {
 	}
 }
 
+class SaveRelationshipsTests: SpineTests {
+
+	var fixture: (data: NSData, json: JSON)!
+	var foo: Foo!
+
+	override func setUp() {
+		super.setUp()
+
+		fixture = JSONFixtureWithName("SingleFooIncludingBars")
+
+		do {
+			let document = try spine.serializer.deserializeData(fixture.data)
+			foo = document.data!.first as! Foo
+		} catch let error as NSError {
+			XCTFail("Deserialisation failed with error: \(error).")
+		}
+	}
+
+	func testItShouldPATCHToOne() {
+		var relationshipUpdated = false
+
+		HTTPClient.handler = { request, payload in
+			if(request.HTTPMethod! == "PATCH" && request.URL! == NSURL(string: "http://example.com/foos/1/relationships/to-one-attribute")!) {
+				let data = JSON(data: payload!)["data"].dictionary!
+				if data["type"]!.string == "bars" && data["id"]!.string == "10" {
+					relationshipUpdated = true
+				}
+			}
+			return (responseData: self.fixture.data, statusCode: 201, error: nil)
+		}
+
+		let future = spine.save(foo)
+		let expectation = expectationWithDescription("")
+		assertFutureSuccess(future, expectation: expectation)
+
+		waitForExpectationsWithTimeout(10) { error in
+			XCTAssertNil(error, "\(error)")
+			XCTAssertTrue(relationshipUpdated)
+		}
+	}
+
+	func testItShouldDELETEToOne() {
+		var relationshipUpdated = false
+
+		HTTPClient.handler = { request, payload in
+			if(request.HTTPMethod! == "DELETE" && request.URL! == NSURL(string: "http://example.com/foos/1/relationships/to-one-attribute")!) {
+				if payload == nil {
+					relationshipUpdated = true
+				}
+			}
+			return (responseData: self.fixture.data, statusCode: 201, error: nil)
+		}
+
+		foo.toOneAttribute = nil
+
+		let future = spine.save(foo)
+		let expectation = expectationWithDescription("")
+		assertFutureSuccess(future, expectation: expectation)
+
+		waitForExpectationsWithTimeout(10) { error in
+			XCTAssertNil(error, "\(error)")
+			XCTAssertTrue(relationshipUpdated)
+		}
+	}
+
+	func testItShouldPOSTToMany() {
+		var relationshipUpdated = false
+
+		HTTPClient.handler = { request, payload in
+			if(request.HTTPMethod! == "POST" && request.URL! == NSURL(string: "http://example.com/foos/1/relationships/to-many-attribute")!) {
+				let data = JSON(data: payload!)["data"].array!
+				XCTAssertEqual(data.count, 1, "Expected data count to be 1.")
+
+				if data[0]["type"].string == "bars" && data[0]["id"].string == "13" {
+					relationshipUpdated = true
+				}
+			}
+			return (responseData: self.fixture.data, statusCode: 201, error: nil)
+		}
+
+		let bar = Bar(id: "13")
+		foo.toManyAttribute!.addResource(bar)
+
+		let future = spine.save(foo)
+		let expectation = expectationWithDescription("")
+		assertFutureSuccess(future, expectation: expectation)
+
+		waitForExpectationsWithTimeout(10) { error in
+			XCTAssertNil(error, "\(error)")
+			XCTAssertTrue(relationshipUpdated)
+		}
+	}
+
+	func testItShouldDELETEToMany() {
+		var relationshipUpdated = false
+
+		HTTPClient.handler = { request, payload in
+			if(request.HTTPMethod! == "DELETE" && request.URL! == NSURL(string: "http://example.com/foos/1/relationships/to-many-attribute")!) {
+				let data = JSON(data: payload!)["data"].array!
+				XCTAssertEqual(data.count, 1, "Expected data count to be 1.")
+
+				if data[0]["type"].string == "bars" && data[0]["id"].string == "11" {
+					relationshipUpdated = true
+				}
+			}
+			return (responseData: self.fixture.data, statusCode: 201, error: nil)
+		}
+
+		let bar = foo.toManyAttribute!.resources.first!
+		foo.toManyAttribute!.removeResource(bar)
+
+		let future = spine.save(foo)
+		let expectation = expectationWithDescription("")
+		assertFutureSuccess(future, expectation: expectation)
+
+		waitForExpectationsWithTimeout(10) { error in
+			XCTAssertNil(error, "\(error)")
+			XCTAssertTrue(relationshipUpdated)
+		}
+	}
+
+}
 
 class PaginatingTests: SpineTests {
 	func testLoadNextPageInCollection() {

--- a/SpineTests/SpineTests.swift
+++ b/SpineTests/SpineTests.swift
@@ -560,6 +560,26 @@ class SaveRelationshipsTests: SpineTests {
 		}
 	}
 
+	func testItShouldFailOnAPIError() {
+		HTTPClient.handler = { request, payload in
+			print(request.URL!)
+			if(request.HTTPMethod! == "DELETE" && request.URL! == NSURL(string: "http://example.com/foos/1/relationships/to-one-attribute")!) {
+				return (responseData: nil, statusCode: 422, error: NSError(domain: "SimulatedAPIError", code: 422, userInfo: nil))
+			}
+			return (responseData: self.fixture.data, statusCode: 201, error: nil)
+		}
+
+		foo.toOneAttribute = nil
+
+		let expectation = expectationWithDescription("SimulatedAPIError")
+		let future = spine.save(foo)
+		assertFutureFailure(future, withErrorDomain: "SimulatedAPIError", errorCode: 422, expectation: expectation)
+
+		waitForExpectationsWithTimeout(10) { error in
+			XCTAssertNil(error, "\(error)")
+		}
+	}
+
 }
 
 class PaginatingTests: SpineTests {


### PR DESCRIPTION
- [x] Get rid of `URLForRelationship` in favor of relationship links
- [x] Fix `RelationshipRemoveOperation` to actually do the thing
- [x] Adjust payload format for all relationship operations according to the spec
- [x] Allow removing toOne relationship
- [x] Properly handle relationship persistence errors