### PR TITLE
Do not make unnecessary modifications to addedResources/removedResources

### DIFF
--- a/Spine/ResourceCollection.swift
+++ b/Spine/ResourceCollection.swift
@@ -155,10 +155,14 @@ public class LinkedResourceCollection: ResourceCollection {
 	*/
 	public func addResource(resource: Resource) {
 		resources.append(resource)
-		addedResources.append(resource)
-		removedResources = removedResources.filter { $0 !== resource }
+
+		if let index = removedResources.indexOf(resource) {
+			removedResources.removeAtIndex(index)
+		} else {
+			addedResources.append(resource)
+		}
 	}
-	
+
 	/**
 	Adds the given resources to this collection. This marks the resources as added.
 	
@@ -177,10 +181,14 @@ public class LinkedResourceCollection: ResourceCollection {
 	*/
 	public func removeResource(resource: Resource) {
 		resources = resources.filter { $0 !== resource }
-		addedResources = addedResources.filter { $0 !== resource }
-		removedResources.append(resource)
+
+		if let index = addedResources.indexOf(resource) {
+			addedResources.removeAtIndex(index)
+		} else {
+			removedResources.append(resource)
+		}
 	}
-	
+
 	/**
 	Adds the given resource to this collection, but does not mark it as added.
 	

--- a/SpineTests/ResourceCollectionTests.swift
+++ b/SpineTests/ResourceCollectionTests.swift
@@ -89,8 +89,8 @@ class LinkedResourceCollectionTests: XCTestCase {
 		collection.addResourceAsExisting(foo)
 		
 		XCTAssert(collection.resources == [foo], "Expected collection to contain resource.")
-		XCTAssert(collection.addedResources.isEmpty , "Expected addedResources to be empty.")
-		XCTAssert(collection.removedResources.isEmpty , "Expected addedResources to be empty.")
+		XCTAssert(collection.addedResources.isEmpty, "Expected addedResources to be empty.")
+		XCTAssert(collection.removedResources.isEmpty, "Expected addedResources to be empty.")
 	}
 	
 	func testAdd() {
@@ -102,15 +102,40 @@ class LinkedResourceCollectionTests: XCTestCase {
 		XCTAssert(collection.resources == [foo], "Expected collection to contain resource.")
 		XCTAssert(collection.addedResources == [foo], "Expected addedResources to contain resource.")
 	}
-	
+
+	func testAddRemoved() {
+		let collection = LinkedResourceCollection(resourcesURL: nil, linkURL: nil, linkage: nil)
+		let foo = Foo()
+
+		collection.addResourceAsExisting(foo)
+		collection.removeResource(foo)
+		collection.addResource(foo)
+
+		XCTAssert(collection.resources == [foo], "Expected collection to contain resource.")
+		XCTAssert(collection.addedResources.isEmpty, "Expected addedResources to be empty.")
+		XCTAssert(collection.removedResources.isEmpty, "Expected removedResources to be empty.")
+	}
+
 	func testRemove() {
 		let collection = LinkedResourceCollection(resourcesURL: nil, linkURL: nil, linkage: nil)
 		let foo = Foo()
 		
-		collection.addResource(foo)
+		collection.addResourceAsExisting(foo)
 		collection.removeResource(foo)
 		
 		XCTAssert(collection.resources.isEmpty, "Expected collection to be empty.")
-		XCTAssert(collection.removedResources == [foo] , "Expected removedResource to contain resource.")
+		XCTAssert(collection.removedResources == [foo], "Expected removedResources to contain resource.")
+	}
+
+	func testRemoveAdded() {
+		let collection = LinkedResourceCollection(resourcesURL: nil, linkURL: nil, linkage: nil)
+		let foo = Foo()
+
+		collection.addResource(foo)
+		collection.removeResource(foo)
+
+		XCTAssert(collection.resources.isEmpty, "Expected collection to be empty.")
+		XCTAssert(collection.addedResources.isEmpty, "Expected addedResources to be empty.")
+		XCTAssert(collection.removedResources.isEmpty, "Expected removedResources to be empty.")
 	}
 }


### PR DESCRIPTION
This fixes the case when persisting changes given there were previously loaded resources. Otherwise invalid requests will be sent in attempt to create already existing relations or to remove inexistent.