### PR TITLE
Swifty errors

### DIFF
--- a/Spine/Errors.swift
+++ b/Spine/Errors.swift
@@ -40,3 +40,63 @@ public struct SpineErrorCodes {
 	/// The given resource coulde not be found.
 	public static let ResourceNotFound = 404
 }
+
+/// TODO: Ideally this is a struct, but we can't store structs in the userInfo of an NSError.
+/// The correct thing to do would probably be to replace NSError with a Spine Error enum.
+/// In the meantime, this is a class so we can still work with the current NSError infrastructure.
+public class APIError: ErrorType {
+	public var id: String?
+	public var status: String?
+	public var code: String?
+	public var title: String?
+	public var detail: String?
+	public var sourcePointer: String?
+	public var sourceParameter: String?
+	public var meta: [String: AnyObject]?
+	
+	init(id: String?, status: String?, code: String?, title: String?, detail: String?, sourcePointer: String?, sourceParameter: String?, meta: [String: AnyObject]?) {
+		self.id = id
+		self.status = status
+		self.code = code
+		self.title = title
+		self.detail = detail
+		self.sourcePointer = sourcePointer
+		self.sourceParameter = sourceParameter
+		self.meta = meta
+	}
+}
+
+public enum SpineError: ErrorType {
+	case UnknownError
+	case NextPageNotAvailable
+	case PreviousPageNotAvailable
+	case ResourceNotFound
+	case SerializerError
+	case ServerError(statusCode: Int, apiErrors: [APIError]?)
+	case NetworkError(NSError)
+}
+
+public enum SerializerError: ErrorType {
+	case UnknownError
+	
+	/// The given JSON is not a dictionary (hash).
+	case InvalidDocumentStructure
+	
+	/// None of 'data', 'errors', or 'meta' is present in the top level.
+	case TopLevelEntryMissing
+	
+	/// Top level 'data' and 'errors' coexist in the same document.
+	case TopLevelDataAndErrorsCoexist
+	
+	/// The given JSON is not a dictionary (hash).
+	case InvalidResourceStructure
+	
+	/// 'Type' field is missing from resource JSON.
+	case ResourceTypeMissing
+	
+	/// 'ID' field is missing from resource JSON.
+	case ResourceIDMissing
+	
+	/// Error occurred in NSJSONSerialization
+	case JSONSerializationError(NSError)
+}

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -259,7 +259,7 @@ class SaveOperation: ConcurrentOperation {
 		}
 		
 		do {
-			let payload = try serializePayload(resource, options: options)
+			payload = try serializePayload(resource, options: options)
 		} catch let error {
 			self.result = .Failure(error as! SpineError)
 			self.state = .Finished
@@ -416,7 +416,7 @@ private class RelationshipOperation: ConcurrentOperation {
 			} catch let error as SpineError {
 				self.result = .Failure(error)
 			} catch {
-				self.result = .Failure(SpineError.DeserializingError)
+				self.result = .Failure(SpineError.SerializerError)
 			}
 		} else {
 			self.result = .Failure(errorFromStatusCode(statusCode!))

--- a/Spine/SerializeOperation.swift
+++ b/Spine/SerializeOperation.swift
@@ -18,7 +18,7 @@ class SerializeOperation: NSOperation {
 	let keyFormatter: KeyFormatter
 	var options: SerializationOptions = [.IncludeID]
 	
-	var result: Failable<NSData>?
+	var result: Failable<NSData, SerializerError>?
 	
 	
 	// MARK: Initializers
@@ -47,7 +47,7 @@ class SerializeOperation: NSOperation {
 			let serialized = try NSJSONSerialization.dataWithJSONObject(["data": JSON], options: NSJSONWritingOptions(rawValue: 0))
 			result = Failable.Success(serialized)
 		} catch let error as NSError {
-			result = Failable.Failure(error)
+			result = Failable.Failure(SerializerError.JSONSerializationError(error))
 		}
 	}
 	

--- a/Spine/Serializing.swift
+++ b/Spine/Serializing.swift
@@ -120,7 +120,7 @@ public struct JSONAPIDocument {
 	public var included: [Resource]?
 	
 	/// Errors extracted from the response.
-	public var errors: [NSError]?
+	public var errors: [APIError]?
 	
 	/// Metadata extracted from the reponse.
 	public var meta: [String: AnyObject]?

--- a/SpineTests/CallbackHTTPClient.swift
+++ b/SpineTests/CallbackHTTPClient.swift
@@ -59,9 +59,18 @@ public class CallbackHTTPClient: NetworkClient {
 		}
 	}
 	
-	func simulateNetworkErrorWithCode(code: Int) {
+	/**
+	Simulates a network error with the given error code.
+	
+	- parameter code: The error code.
+	
+	- returns: The NSError that will be returned as the simulated network error.
+	*/
+	func simulateNetworkErrorWithCode(code: Int) -> NSError {
+		let error = NSError(domain: "SimulatedNetworkError", code: code, userInfo: nil)
 		handler = { request, payload in
-			return (responseData: nil, statusCode: nil, error: NSError(domain: "SimulatedNetworkError", code: code, userInfo: nil))
+			return (responseData: nil, statusCode: nil, error: error)
 		}
+		return error
 	}
 }

--- a/SpineTests/Fixtures/Errors.json
+++ b/SpineTests/Fixtures/Errors.json
@@ -1,21 +1,15 @@
 {
    "errors": [{
-      "title": "First error title",
-      "detail": "First error detail.",
-      "id": null,
-      "href": null,
-      "code": 100,
-      "path": null,
-      "links": null,
-      "status": "first_error_status"
+			"id": "Error id 1",
+			"status": "Error status 1",
+      "code": "1",
+      "title": "Error title 1",
+      "detail": "Error detail 1"
    }, {
-      "title": "Second error title",
-      "detail": "Second error detail.",
-      "id": null,
-      "href": null,
-      "code": 500,
-      "path": null,
-      "links": null,
-      "status": "second_error_status"
+      "id": "Error id 2",
+      "status": "Error status 2",
+      "code": "2",
+      "title": "Error title 2",
+      "detail": "Error detail 2"
    }]
 }

--- a/SpineTests/SerializingTests.swift
+++ b/SpineTests/SerializingTests.swift
@@ -255,10 +255,10 @@ class DeserializingTests: SerializerTests {
 		do {
 			try serializer.deserializeData(data)
 			XCTFail("Expected deserialization to fail.")
-			
-		} catch let error as NSError {
-			XCTAssertEqual(error.domain, SpineSerializingErrorDomain, "Expected error domain to be SpineSerializingErrorDomain.")
-			XCTAssertEqual(error.code, SpineErrorCodes.InvalidDocumentStructure, "Expected error code to be 'InvalidDocumentStructure'.")
+		} catch SerializerError.InvalidDocumentStructure {
+			// All is well
+		} catch {
+			XCTFail("Expected error domain to be SerializerError.TopLevelEntryMissing.")
 		}
 	}
 	
@@ -275,13 +275,15 @@ class DeserializingTests: SerializerTests {
 				
 				for (index, error) in errors.enumerate() {
 					let errorJSON = fixture.json["errors"][index]
-					XCTAssertEqual(error.domain, SpineServerErrorDomain, "Expected error domain to be SpineServerErrorDomain.")
-					XCTAssertEqual(error.code, errorJSON["code"].intValue, "Expected error code to be equal.")
-					XCTAssertEqual(error.localizedDescription, errorJSON["title"].stringValue, "Expected error description to be equal.")
+					XCTAssertEqual(error.id, errorJSON["id"].stringValue)
+					XCTAssertEqual(error.status, errorJSON["status"].stringValue)
+					XCTAssertEqual(error.code, errorJSON["code"].stringValue)
+					XCTAssertEqual(error.title, errorJSON["title"].stringValue)
+					XCTAssertEqual(error.detail, errorJSON["detail"].stringValue)
 				}
 			}
 			
-		} catch let error as NSError {
+		} catch let error {
 			XCTFail("Deserialisation failed with error: \(error).")
 		}
 	}

--- a/SpineTests/SpineTests.swift
+++ b/SpineTests/SpineTests.swift
@@ -62,7 +62,7 @@ class FindAllTests: SpineTests {
 		
 		let expectation = expectationWithDescription("testFindByTypeWithAPIError")
 		let future = spine.findAll(Foo.self)
-		assertFutureFailure(future, withErrorDomain: SpineServerErrorDomain, errorCode: 404, expectation: expectation)
+		assertFutureFailure(future, withStatusCode: 404, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -70,11 +70,11 @@ class FindAllTests: SpineTests {
 	}
 	
 	func testItShouldFailOnNetworkError() {
-		HTTPClient.simulateNetworkErrorWithCode(999)
-		
+		let networkError = HTTPClient.simulateNetworkErrorWithCode(999)
 		let expectation = expectationWithDescription("testFindByTypeWithNetworkError")
 		let future = spine.findAll(Foo.self)
-		assertFutureFailure(future, withErrorDomain: "SimulatedNetworkError", errorCode: 999, expectation: expectation)
+		
+		assertFutureFailure(future, withError: SpineError.NetworkError(networkError), expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -118,7 +118,7 @@ class FindByIDTests: SpineTests {
 		
 		let expectation = expectationWithDescription("testFindByIDAndTypeWithAPIError")
 		let future = spine.find(["1","2"], ofType: Foo.self)
-		assertFutureFailure(future, withErrorDomain: SpineServerErrorDomain, errorCode: 404, expectation: expectation)
+		assertFutureFailure(future, withStatusCode: 404, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -126,11 +126,11 @@ class FindByIDTests: SpineTests {
 	}
 	
 	func testItShouldFailOnNetworkError() {
-		HTTPClient.simulateNetworkErrorWithCode(999)
-		
+		let networkError = HTTPClient.simulateNetworkErrorWithCode(999)
 		let expectation = expectationWithDescription("testFindByIDAndTypeWithNetworkError")
 		let future = spine.find(["1","2"], ofType: Foo.self)
-		assertFutureFailure(future, withErrorDomain: "SimulatedNetworkError", errorCode: 999, expectation: expectation)
+		
+		assertFutureFailure(future, withError: SpineError.NetworkError(networkError), expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -168,7 +168,7 @@ class FindOneByIDTests: SpineTests {
 		
 		let expectation = expectationWithDescription("testFindOneByTypeWithAPIError")
 		let future = spine.findOne("1", ofType: Foo.self)
-		assertFutureFailure(future, withErrorDomain: SpineServerErrorDomain, errorCode: 404, expectation: expectation)
+		assertFutureFailure(future, withStatusCode: 404, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -176,11 +176,11 @@ class FindOneByIDTests: SpineTests {
 	}
 	
 	func testItShouldFailOnNetworkError() {
-		HTTPClient.simulateNetworkErrorWithCode(999)
-		
+		let networkError = HTTPClient.simulateNetworkErrorWithCode(999)
 		let expectation = expectationWithDescription("testFindOneByTypeWithNetworkError")
 		let future = spine.findOne("1", ofType: Foo.self)
-		assertFutureFailure(future, withErrorDomain: "SimulatedNetworkError", errorCode: 999, expectation: expectation)
+		
+		assertFutureFailure(future, withError: SpineError.NetworkError(networkError), expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")

--- a/SpineTests/SpineTests.swift
+++ b/SpineTests/SpineTests.swift
@@ -62,7 +62,7 @@ class FindAllTests: SpineTests {
 		
 		let expectation = expectationWithDescription("testFindByTypeWithAPIError")
 		let future = spine.findAll(Foo.self)
-		assertFutureFailure(future, withStatusCode: 404, expectation: expectation)
+		assertFutureFailureWithServerError(future, statusCode: 404, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -70,11 +70,11 @@ class FindAllTests: SpineTests {
 	}
 	
 	func testItShouldFailOnNetworkError() {
-		let networkError = HTTPClient.simulateNetworkErrorWithCode(999)
+		HTTPClient.simulateNetworkErrorWithCode(999)
 		let expectation = expectationWithDescription("testFindByTypeWithNetworkError")
 		let future = spine.findAll(Foo.self)
 		
-		assertFutureFailure(future, withError: SpineError.NetworkError(networkError), expectation: expectation)
+		assertFutureFailureWithNetworkError(future, code: 999, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -118,7 +118,7 @@ class FindByIDTests: SpineTests {
 		
 		let expectation = expectationWithDescription("testFindByIDAndTypeWithAPIError")
 		let future = spine.find(["1","2"], ofType: Foo.self)
-		assertFutureFailure(future, withStatusCode: 404, expectation: expectation)
+		assertFutureFailureWithServerError(future, statusCode: 404, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -126,11 +126,11 @@ class FindByIDTests: SpineTests {
 	}
 	
 	func testItShouldFailOnNetworkError() {
-		let networkError = HTTPClient.simulateNetworkErrorWithCode(999)
+		HTTPClient.simulateNetworkErrorWithCode(999)
 		let expectation = expectationWithDescription("testFindByIDAndTypeWithNetworkError")
 		let future = spine.find(["1","2"], ofType: Foo.self)
 		
-		assertFutureFailure(future, withError: SpineError.NetworkError(networkError), expectation: expectation)
+		assertFutureFailureWithNetworkError(future, code: 999, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -168,7 +168,7 @@ class FindOneByIDTests: SpineTests {
 		
 		let expectation = expectationWithDescription("testFindOneByTypeWithAPIError")
 		let future = spine.findOne("1", ofType: Foo.self)
-		assertFutureFailure(future, withStatusCode: 404, expectation: expectation)
+		assertFutureFailureWithServerError(future, statusCode: 404, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -226,7 +226,7 @@ class FindByQueryTests: SpineTests {
 		
 		let query = Query(resourceType: Foo.self, resourceIDs: ["1"])
 		let future = spine.find(query)
-		assertFutureFailure(future, withErrorDomain: SpineServerErrorDomain, errorCode: 404, expectation: expectation)
+		assertFutureFailureWithServerError(future, statusCode: 404, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -240,7 +240,7 @@ class FindByQueryTests: SpineTests {
 		
 		let query = Query(resourceType: Foo.self, resourceIDs: ["1"])
 		let future = spine.find(query)
-		assertFutureFailure(future, withErrorDomain: "SimulatedNetworkError", errorCode: 999, expectation: expectation)
+		assertFutureFailureWithNetworkError(future, code: 999, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -281,7 +281,7 @@ class FindOneByQueryTests: SpineTests {
 		
 		let query = Query(resourceType: Foo.self, resourceIDs: ["1"])
 		let future = spine.findOne(query)
-		assertFutureFailure(future, withErrorDomain: SpineServerErrorDomain, errorCode: 404, expectation: expectation)
+		assertFutureFailureWithServerError(future, statusCode: 404, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -295,7 +295,7 @@ class FindOneByQueryTests: SpineTests {
 		
 		let query = Query(resourceType: Foo.self, resourceIDs: ["1"])
 		let future = spine.findOne(query)
-		assertFutureFailure(future, withErrorDomain: "SimulatedNetworkError", errorCode: 999, expectation: expectation)
+		assertFutureFailureWithNetworkError(future, code: 999, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -335,7 +335,7 @@ class DeleteTests: SpineTests {
 		let bar = Bar(id: "1")
 		let expectation = expectationWithDescription("testDeleteResourceWithAPIError")
 		let future = spine.delete(bar)
-		assertFutureFailure(future, withErrorDomain: SpineServerErrorDomain, errorCode: 404, expectation: expectation)
+		assertFutureFailureWithServerError(future, statusCode: 404, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -348,7 +348,7 @@ class DeleteTests: SpineTests {
 		let bar = Bar(id: "1")
 		let expectation = expectationWithDescription("testDeleteResourceWithNetworkError")
 		let future = spine.delete(bar)
-		assertFutureFailure(future, withErrorDomain: "SimulatedNetworkError", errorCode: 999, expectation: expectation)
+		assertFutureFailureWithNetworkError(future, code: 999, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -418,7 +418,7 @@ class SaveTests: SpineTests {
 		let foo = Foo()
 		let expectation = expectationWithDescription("testCreateResourceWithAPIError")
 		let future = spine.save(foo)
-		assertFutureFailure(future, withErrorDomain: SpineServerErrorDomain, errorCode: 400, expectation: expectation)
+		assertFutureFailureWithServerError(future, statusCode: 400, expectation: expectation)
 
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")
@@ -431,7 +431,7 @@ class SaveTests: SpineTests {
 		let foo = Foo()
 		let expectation = expectationWithDescription("testDeleteResourceWithNetworkError")
 		let future = spine.save(foo)
-		assertFutureFailure(future, withErrorDomain: "SimulatedNetworkError", errorCode: 999, expectation: expectation)
+		assertFutureFailureWithNetworkError(future, code: 999, expectation: expectation)
 		
 		waitForExpectationsWithTimeout(10) { error in
 			XCTAssertNil(error, "\(error)")

--- a/SpineTests/Utilities.swift
+++ b/SpineTests/Utilities.swift
@@ -41,19 +41,18 @@ func assertFutureSuccess<T, E>(future: Future<T, E>, expectation: XCTestExpectat
 	}
 }
 
-func assertFutureFailure<T>(future: Future<T, NSError>, withError expectedError: NSError, expectation: XCTestExpectation) {
+func assertFutureFailure<T>(future: Future<T, SpineError>, withError expectedError: SpineError, expectation: XCTestExpectation) {
 	future.onSuccess { resources in
 		expectation.fulfill()
 		XCTFail("Expected success callback to not be called.")
 	}.onFailure { error in
 		expectation.fulfill()
-		XCTAssertEqual(error.domain, expectedError.domain, "Expected error domain to be \(expectedError.domain).")
-		XCTAssertEqual(error.code, expectedError.code, "Expected error code to be \(expectedError.code).")
+		XCTAssertEqual(error, expectedError, "Expected error to be be \(expectedError).")
 	}
 }
 
-func assertFutureFailure<T>(future: Future<T, NSError>, withErrorDomain domain: String, errorCode code: Int, expectation: XCTestExpectation) {
-	let expectedError = NSError(domain: domain, code: code, userInfo: nil)
+func assertFutureFailure<T>(future: Future<T, SpineError>, withStatusCode code: Int, expectation: XCTestExpectation) {
+	let expectedError = SpineError.ServerError(statusCode: code, apiErrors: nil)
 	assertFutureFailure(future, withError: expectedError, expectation: expectation)
 }
 


### PR DESCRIPTION
Replaced NSError with ErrorType enums. See issue https://github.com/wvteijlingen/Spine/issues/60.