### PR TITLE
Fixes PATCH without relationship not fulfilling promise

### DIFF
--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -326,6 +326,9 @@ class SaveOperation: ConcurrentOperation {
 			if let error = result.error {
 				self.relationshipOperationQueue.cancelAllOperations()
 				self.result = Failable(error)
+			} else {
+				self.result = Failable.Success()
+				self.state = .Finished
 			}
 		}
 		
@@ -345,6 +348,8 @@ class SaveOperation: ConcurrentOperation {
 				removeOperation.completionBlock = { [unowned removeOperation] in completionHandler(result: removeOperation.result!) }
 				relationshipOperationQueue.addOperation(removeOperation)
 			default: ()
+				self.result = Failable.Success()
+				self.state = .Finished
 			}
 		}
 	}


### PR DESCRIPTION
When you do a PATCH and the resource has no relationships, given it's a
PATCH, the code for updating relationships is executed, according to the
code below:

```swift
if self.isNewResource {
  self.result = Failable.Success()
  self.state = .Finished
} else {
  self.updateRelationships()
}
```

The `updateRelationship()` method fulfill promises except when the
resource has no `toOne` or `toMany` relationships (`case`'s `default`
branch).