### PR TITLE
Public field name

### DIFF
--- a/Spine/ResourceField.swift
+++ b/Spine/ResourceField.swift
@@ -23,11 +23,11 @@ public class Field {
 	/// The name of the field as it appears in the model class.
 	/// This is declared as an implicit optional to support the `fieldsFromDictionary` function,
 	/// however it should *never* be nil.
-	var name: String! = nil
+	public internal(set) var name: String! = nil
 	
 	/// The name of the field that will be used for formatting to the JSON key.
 	/// This can be nil, in which case the regular name will be used.
-	var serializedName: String {
+	public internal(set) var serializedName: String {
 		get {
 			return _serializedName ?? name
 		}


### PR DESCRIPTION
It's very useful to be able to iterate a model's fields, but it's currently impossible to use Spine's `fields` array, because the fields' `name` and `serializedName` are internal instead of public.
This PR makes the getters of those two properties public.