### PR TITLE
Fix arbitrary filters

### DIFF
--- a/Spine/Query.swift
+++ b/Spine/Query.swift
@@ -135,6 +135,14 @@ public struct Query<T: Resource> {
 	// MARK: Filtering
 	
 	private mutating func addPredicateWithField(fieldName: String, value: AnyObject, type: NSPredicateOperatorType) {
+		if let field = T.fields.filter({ $0.name == fieldName }).first {
+            addPredicateWithFieldName(field.name, value: value, type: type)
+		} else {
+			assertionFailure("Resource of type \(T.resourceType) does not contain a field named \(fieldName)")
+		}
+	}
+    
+    private mutating func addPredicateWithFieldName(fieldName: String, value: AnyObject, type: NSPredicateOperatorType) {
         let predicate = NSComparisonPredicate(
             leftExpression: NSExpression(forKeyPath: fieldName),
             rightExpression: NSExpression(forConstantValue: value),
@@ -225,6 +233,78 @@ public struct Query<T: Resource> {
 	public mutating func whereAttribute(attributeName: String, greaterThanOrEqualTo: AnyObject) {
 		addPredicateWithField(attributeName, value: greaterThanOrEqualTo, type: .GreaterThanOrEqualToPredicateOperatorType)
 	}
+    
+    /**
+     Adds a filter where the given attribute should be equal to the given value.
+     
+     - parameter attributeName: The name of the attribute to filter on.
+     - parameter equals:        The value to check for.
+     
+     - returns: The query
+     */
+    public mutating func filterOn(attributeName: String, equalTo: AnyObject) {
+        addPredicateWithFieldName(attributeName, value: equalTo, type: .EqualToPredicateOperatorType)
+    }
+    
+    /**
+     Adds a filter where the given attribute should not be equal to the given value.
+     
+     - parameter attributeName: The name of the attribute to filter on.
+     - parameter equals:        The value to check for.
+     
+     - returns: The query
+     */
+    public mutating func filterOn(attributeName: String, notEqualTo: AnyObject) {
+        addPredicateWithFieldName(attributeName, value: notEqualTo, type: .NotEqualToPredicateOperatorType)
+    }
+    
+    /**
+     Adds a filter where the given attribute should be smaller than the given value.
+     
+     - parameter attributeName: The name of the attribute to filter on.
+     - parameter smallerThen:   The value to check for.
+     
+     - returns: The query
+     */
+    public mutating func filterOn(attributeName: String, lessThan: AnyObject) {
+        addPredicateWithFieldName(attributeName, value: lessThan, type: .LessThanPredicateOperatorType)
+    }
+    
+    /**
+     Adds a filter where the given attribute should be less then or equal to the given value.
+     
+     - parameter attributeName: The name of the attribute to filter on.
+     - parameter smallerThen:   The value to check for.
+     
+     - returns: The query
+     */
+    public mutating func filterOn(attributeName: String, lessThanOrEqualTo: AnyObject) {
+        addPredicateWithFieldName(attributeName, value: lessThanOrEqualTo, type: .LessThanOrEqualToPredicateOperatorType)
+    }
+    
+    /**
+     Adds a filter where the given attribute should be greater then the given value.
+     
+     - parameter attributeName: The name of the attribute to filter on.
+     - parameter greaterThen:   The value to check for.
+     
+     - returns: The query
+     */
+    public mutating func filterOn(attributeName: String, greaterThan: AnyObject) {
+        addPredicateWithFieldName(attributeName, value: greaterThan, type: .GreaterThanPredicateOperatorType)
+    }
+    
+    /**
+     Adds a filter where the given attribute should be greater than or equal to the given value.
+     
+     - parameter attributeName: The name of the attribute to filter on.
+     - parameter greaterThen:   The value to check for.
+     
+     - returns: The query
+     */
+    public mutating func filterOn(attributeName: String, greaterThanOrEqualTo: AnyObject) {
+        addPredicateWithFieldName(attributeName, value: greaterThanOrEqualTo, type: .GreaterThanOrEqualToPredicateOperatorType)
+    }
 	
 	/**
 	Adds a filter where the given relationship should point to the given resource, or the given

--- a/SpineTests/QueryTests.swift
+++ b/SpineTests/QueryTests.swift
@@ -176,6 +176,20 @@ class QueryFilterTests: XCTestCase {
 		
 		XCTAssertEqual(query.filters, [predicate], "Filters not as expected")
 	}
+    
+    func testFilterOnANonAttribute() {
+        var query = Query(resourceType: Foo.self)
+        query.filterOn("notAnAttribute", equalTo: "value")
+        
+        let predicate = NSComparisonPredicate(
+            leftExpression: NSExpression(forKeyPath: "notAnAttribute"),
+            rightExpression: NSExpression(forConstantValue: "value"),
+            modifier: .DirectPredicateModifier,
+            type: .EqualToPredicateOperatorType,
+            options: NSComparisonPredicateOptions())
+        
+        XCTAssertEqual(query.filters, [predicate], "Filters not as expected")
+    }
 	
 }
 

--- a/SpineTests/RoutingTests.swift
+++ b/SpineTests/RoutingTests.swift
@@ -31,6 +31,16 @@ class RoutingTests: XCTestCase {
 		
 		XCTAssertEqual(URL, expectedURL, "URL not as expected.")
 	}
+    
+    func testURLForQueryWithNonAttributeFilter() {
+        var query = Query(resourceType: Foo.self, resourceIDs: ["1", "2"])
+        query.filterOn("notAnAttribute", equalTo: "stringValue")
+        
+        let URL = spine.router.URLForQuery(query)
+        let expectedURL = NSURL(string: "http://example.com/foos?filter[id]=1,2&filter[notAnAttribute]=stringValue")!
+        
+        XCTAssertEqual(URL, expectedURL, "URL not as expected.")
+    }
 	
 	func testPagePagination() {
 		var query = Query(resourceType: Foo.self)


### PR DESCRIPTION
Unfortunately, I made a mistake in #83 that still prevented arbitrary filters from working. This PR fixes the issue when converting a query to a URL and also adds unit tests for this new use case.