### PR TITLE
Added a serialization option to prevent serializing null values

### DIFF
--- a/Spine/SerializeOperation.swift
+++ b/Spine/SerializeOperation.swift
@@ -98,7 +98,7 @@ class SerializeOperation: NSOperation {
 			//TODO: Dirty checking
 			if let unformattedValue: AnyObject = resource.valueForField(field.name) {
 				addAttribute(&attributes, key: key, value: self.valueFormatters.format(unformattedValue, forAttribute: field))
-			} else {
+			} else if(!options.contains(.OmitNullValues)){
 				addAttribute(&attributes, key: key, value: NSNull())
 			}
 		}

--- a/Spine/Serializing.swift
+++ b/Spine/Serializing.swift
@@ -218,4 +218,7 @@ public struct SerializationOptions: OptionSetType {
 	
 	/// Whether to include to-one linked resources in the serialized representation.
 	public static let IncludeToOne = SerializationOptions(rawValue: 1 << 4)
+    
+    /// If set, then attributes with null values will not be serialized.
+    public static let OmitNullValues = SerializationOptions(rawValue: 1 << 5)
 }

--- a/SpineTests/SerializingTests.swift
+++ b/SpineTests/SerializingTests.swift
@@ -92,6 +92,13 @@ class SerializingTests: SerializerTests {
 		
 		XCTAssertNotNil(json["data"]["relationships"]["to-many-attribute"].error, "Expected serialized to-many to be absent.")
 	}
+    
+    func testSerializeResourceOmittingNulls() {
+        let options: SerializationOptions = [.OmitNullValues]
+        let serializedData = try! serializer.serializeResources([foo], options: options)
+        let json = JSON(data: serializedData)
+        XCTAssertNotNil(json["data"]["attributes"]["nil-attribute"].error, "Expected serialized nil to be absent.")
+    }
 }
 
 class DeserializingTests: SerializerTests {


### PR DESCRIPTION
In cases where you don't want to serialize null values, you can now use the `SerializationOption`, `OmitNullValues`.  