### PR TITLE
Added support for extracting attributes from a key path

### DIFF
--- a/Spine/DeserializeOperation.swift
+++ b/Spine/DeserializeOperation.swift
@@ -208,15 +208,19 @@ class DeserializeOperation: NSOperation {
 	}
 	
 	/**
-	Extracts the value for the given key from the passed serialized data.
+	Extracts the value for the given key path from the passed serialized data.
 	
 	- parameter serializedData: The data from which to extract the attribute.
-	- parameter key:            The key for which to extract the value from the data.
+	- parameter key:            The key path for which to extract the value from the data.
 	
-	- returns: The extracted value or nil if no attribute with the given key was found in the data.
+	- returns: The extracted value or nil if no attribute with the given key path was found in the data.
 	*/
-	private func extractAttribute(serializedData: JSON, key: String) -> AnyObject? {
-		let value = serializedData["attributes"][key]
+    private func extractAttribute(serializedData: JSON, key: String) -> AnyObject? {
+        let parts = key.componentsSeparatedByString(".")
+        var value = serializedData["attributes"]
+        for part in parts {
+            value = value[part]
+        }
 		
 		if let _ = value.null {
 			return nil


### PR DESCRIPTION
Imagine a JSON-API resource as follows:
```json
{
  "data": {
    "type": "videos",
    "id": "123",
    "attributes": {
      "title": "Example Video",
      "stream": {
        "hd-url": "…",
        "sd-url": "…",
        "hls-url": "…",
      }
    }
  }
}
```
It is currently impossible to directly retrieve the attributes from the nested object `stream`.
With this PR, the serialized name of an Attribute can be specified in the "key path" syntax, in this case an Attribute definition could look like this: `"stream_hd_url": Attribute().serializeAs("stream.hls-url")`.

This implementation only handles deserialization, but I could add serialization as well if necessary.