### PR TITLE
Skip unregistered types in included resources

### DIFF
--- a/Spine/DeserializeOperation.swift
+++ b/Spine/DeserializeOperation.swift
@@ -89,7 +89,11 @@ class DeserializeOperation: Operation {
 
 			if let data = data["included"].array {
 				for representation in data {
-					try extractedIncludedResources.append(deserializeSingleRepresentation(representation))
+                    do {
+                        try extractedIncludedResources.append(deserializeSingleRepresentation(representation))
+                    } catch SerializerError.resourceTypeUnregistered(let resourceType) {
+                        Spine.logInfo(.serializing, "Cannot perform deserialization for resource type '\(resourceType)' because it is not registered.")
+                    }
 				}
 			}
 		} catch let error as SerializerError {

--- a/Spine/DeserializeOperation.swift
+++ b/Spine/DeserializeOperation.swift
@@ -92,7 +92,7 @@ class DeserializeOperation: Operation {
                     do {
                         try extractedIncludedResources.append(deserializeSingleRepresentation(representation))
                     } catch SerializerError.resourceTypeUnregistered(let resourceType) {
-                        Spine.logInfo(.serializing, "Cannot perform deserialization for resource type '\(resourceType)' because it is not registered.")
+                        Spine.logWarning(.serializing, "Cannot perform deserialization for resource type '\(resourceType)' because it is not registered.")
                     }
 				}
 			}

--- a/Spine/Errors.swift
+++ b/Spine/Errors.swift
@@ -77,7 +77,7 @@ public enum SerializerError: Error, Equatable {
 	case resourceTypeMissing
 	
 	/// The given resource type has not been registered to Spine.
-	case resourceTypeUnregistered
+    case resourceTypeUnregistered(ResourceType)
 	
 	/// 'ID' field is missing from resource JSON.
 	case resourceIDMissing

--- a/Spine/ResourceFactory.swift
+++ b/Spine/ResourceFactory.swift
@@ -31,7 +31,7 @@ struct ResourceFactory {
 	/// - returns: An instantiated resource.
 	func instantiate(_ type: ResourceType) throws -> Resource {
 		if resourceTypes[type] == nil {
-			throw SerializerError.resourceTypeUnregistered
+			throw SerializerError.resourceTypeUnregistered(type)
 		}
 		return resourceTypes[type]!.init()
 	}

--- a/SpineTests/Fixtures/SingleFooWithUnregisteredType.json
+++ b/SpineTests/Fixtures/SingleFooWithUnregisteredType.json
@@ -32,5 +32,12 @@
 				]
 			}
 		}
-	}
+	},
+    "included": [{
+		"id": "11",
+		"type": "unregistered-types",
+		"links": {
+			"self": "http://example.com/unregistered/11"
+		}
+	}]
 }


### PR DESCRIPTION
Fixes issue in https://github.com/wvteijlingen/Spine/pull/90 where unregistered types in included resources break deserialization. Unsure if this is the best place to do it.