### PR TITLE
Fixed rare crash because of dangling KVO pointer

### DIFF
--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -227,6 +227,11 @@ class SaveOperation: ConcurrentOperation {
 		super.init()
 		self.spine = spine
 		self.relationshipOperationQueue.maxConcurrentOperationCount = 1
+		self.relationshipOperationQueue.addObserver(self, forKeyPath: "operations", options: NSKeyValueObservingOptions(), context: nil)
+	}
+	
+	deinit {
+		relationshipOperationQueue.removeObserver(self, forKeyPath: "operations")
 	}
 	
 	override func execute() {
@@ -315,8 +320,6 @@ class SaveOperation: ConcurrentOperation {
 			self.updateResource()
 			return
 		}
-		
-		self.relationshipOperationQueue.addObserver(self, forKeyPath: "operations", options: NSKeyValueObservingOptions(), context: nil)
 		
 		let completionHandler: (result: Failable<Void, SpineError>?) -> Void = { result in
 			if let error = result?.error {


### PR DESCRIPTION
Sometimes, during CoreAnimation animations, my app would nondeterministicly crash because of a KVO observer callback where the observer has already been deallocated. After a long debugging session I figured out that Spine's `SaveOperation` is the culprit. This PR fixes this issue by adding a matching `removeObserver` call.