### PR TITLE
update only dirty attributes fixed (incl. Test)

### DIFF
--- a/Spine.xcodeproj/project.pbxproj
+++ b/Spine.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		D3BE2B1E1AD56C850061167C /* PagedFoos-2.json in Resources */ = {isa = PBXBuildFile; fileRef = D3BE2B1C1AD56C840061167C /* PagedFoos-2.json */; };
 		D3DFBB6519B9DC64009785BE /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37FB17E19B9D7F10073A888 /* Networking.swift */; };
 		D3E1D1421AAA04B20077B1C3 /* ResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E1D1411AAA04B20077B1C3 /* ResourceTests.swift */; };
+		E2352DA61DAB78FF0044BE67 /* SingleFooNotAllAttributesSet.json in Resources */ = {isa = PBXBuildFile; fileRef = E2352DA41DAB78E10044BE67 /* SingleFooNotAllAttributesSet.json */; };
+		E2352DA71DAB79010044BE67 /* SingleFooNotAllAttributesSet.json in Resources */ = {isa = PBXBuildFile; fileRef = E2352DA41DAB78E10044BE67 /* SingleFooNotAllAttributesSet.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -162,6 +164,7 @@
 		D3BE2B1B1AD56C840061167C /* PagedFoos-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "PagedFoos-1.json"; sourceTree = "<group>"; };
 		D3BE2B1C1AD56C840061167C /* PagedFoos-2.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "PagedFoos-2.json"; sourceTree = "<group>"; };
 		D3E1D1411AAA04B20077B1C3 /* ResourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourceTests.swift; sourceTree = "<group>"; };
+		E2352DA41DAB78E10044BE67 /* SingleFooNotAllAttributesSet.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SingleFooNotAllAttributesSet.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -243,6 +246,7 @@
 				D35DAAEA1A9627FD00E59545 /* Fixtures.swift */,
 				D3502C2C1A93A7F700F91266 /* SingleFoo.json */,
 				D307FBED1A97756700EE0FAC /* SingleFooIncludingBars.json */,
+				E2352DA41DAB78E10044BE67 /* SingleFooNotAllAttributesSet.json */,
 				D35047891A94FF70002FDF57 /* MultipleFoos.json */,
 				D3BE2B1B1AD56C840061167C /* PagedFoos-1.json */,
 				D3BE2B1C1AD56C840061167C /* PagedFoos-2.json */,
@@ -509,6 +513,7 @@
 				240BCA6E1CD9302700842222 /* SingleFoo.json in Resources */,
 				240BCA721CD9303000842222 /* PagedFoos-2.json in Resources */,
 				240BCA711CD9302E00842222 /* PagedFoos-1.json in Resources */,
+				E2352DA71DAB79010044BE67 /* SingleFooNotAllAttributesSet.json in Resources */,
 				240BCA731CD9303300842222 /* Errors.json in Resources */,
 				240BCA701CD9302C00842222 /* MultipleFoos.json in Resources */,
 			);
@@ -529,6 +534,7 @@
 				D350478A1A94FF70002FDF57 /* MultipleFoos.json in Resources */,
 				D3BE2B1D1AD56C840061167C /* PagedFoos-1.json in Resources */,
 				D3502C2D1A93A7F700F91266 /* SingleFoo.json in Resources */,
+				E2352DA61DAB78FF0044BE67 /* SingleFooNotAllAttributesSet.json in Resources */,
 				D307FBEE1A97756700EE0FAC /* SingleFooIncludingBars.json in Resources */,
 				D3BE2B1E1AD56C850061167C /* PagedFoos-2.json in Resources */,
 			);

--- a/Spine/DeserializeOperation.swift
+++ b/Spine/DeserializeOperation.swift
@@ -200,16 +200,39 @@ class DeserializeOperation: NSOperation {
 	private func extractAttributes(serializedData: JSON, intoResource resource: Resource) {
 		for case let field as Attribute in resource.fields {
 			let key = keyFormatter.format(field)
-			if let extractedValue: AnyObject = self.extractAttribute(serializedData, key: key) {
-				let formattedValue: AnyObject = self.valueFormatters.unformat(extractedValue, forAttribute: field)
-				resource.setValue(formattedValue, forField: field.name)
-            } else {
-                resource.setValue(nil, forField: field.name)
+            if valuePresentForKey(serializedData, key: key) {
+                if let extractedValue: AnyObject = self.extractAttribute(serializedData, key: key) {
+                    let formattedValue: AnyObject = self.valueFormatters.unformat(extractedValue, forAttribute: field)
+                    resource.setValue(formattedValue, forField: field.name)
+                } else {
+                    resource.setValue(nil, forField: field.name)
+                }
             }
 		}
 	}
 	
-	/**
+    /**
+     Checks if there is a value for the given key in the passed serialized data.
+     
+     - parameter serializedData: The data from which to extract the attribute.
+     - parameter key:            The key for which to extract the value from the data.
+     
+     - returns: true if there is a value for the given key
+     */
+    private func valuePresentForKey(serializedData: JSON, key: String) -> Bool {
+        let value = serializedData["attributes"][key]
+
+        if let error = value.error {
+            if error.code == ErrorNotExist {
+                return false
+            }
+            // all other errors will be handled if no value is present
+            return false
+        }
+        return true
+    }
+
+    /**
 	Extracts the value for the given key from the passed serialized data.
 	
 	- parameter serializedData: The data from which to extract the attribute.

--- a/Spine/DeserializeOperation.swift
+++ b/Spine/DeserializeOperation.swift
@@ -203,7 +203,9 @@ class DeserializeOperation: NSOperation {
 			if let extractedValue: AnyObject = self.extractAttribute(serializedData, key: key) {
 				let formattedValue: AnyObject = self.valueFormatters.unformat(extractedValue, forAttribute: field)
 				resource.setValue(formattedValue, forField: field.name)
-			}
+            } else {
+                resource.setValue(nil, forField: field.name)
+            }
 		}
 	}
 	

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -251,7 +251,7 @@ class SaveOperation: ConcurrentOperation {
 		} else {
 			URL = router.URLForQuery(Query(resource: resource))
 			method = "PATCH"
-			options = [.IncludeID]
+			options = [.IncludeID, .DirtyFieldsOnly]
 		}
 		
 		let payload: NSData

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -240,6 +240,12 @@ class SaveOperation: ConcurrentOperation {
 	}
 
 	private func updateResource() {
+        if !isNewResource && !resource.isDirty() {
+            self.result = .Success()
+            self.state = .Finished
+            return
+        }
+        
 		let URL: NSURL
 		let method: String
 		let options: SerializationOptions

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -240,7 +240,7 @@ class SaveOperation: ConcurrentOperation {
 	}
 
 	private func updateResource() {
-        if !isNewResource && !resource.isDirty() {
+        if !isNewResource && !resource.isDirty {
             self.result = .Success()
             self.state = .Finished
             return

--- a/Spine/Operation.swift
+++ b/Spine/Operation.swift
@@ -315,7 +315,7 @@ class SaveOperation: ConcurrentOperation {
 	}
 
 	private func updateRelationships() {
-		let relationships = resource.fields.filter { $0 is Relationship }
+		let relationships = resource.fields.filter { $0 is Relationship && resource.isDirty($0.name) }
 		
 		guard !relationships.isEmpty else {
 			self.updateResource()

--- a/Spine/Resource.swift
+++ b/Spine/Resource.swift
@@ -108,6 +108,16 @@ public class Resource: NSObject, NSCoding {
 	var relationships: [String: RelationshipData] = [:]
 	
 	var originalValues: [String: AnyObject] = [:]
+    
+    var isDirty: Bool {
+        var dirty = false
+        for field in fields {
+            if isDirty(field.name) {
+                dirty = true
+            }
+        }
+        return dirty
+    }
 	
 	public required override init() {
 		super.init()
@@ -152,16 +162,6 @@ public class Resource: NSObject, NSCoding {
 		originalValues[field] = value ?? NSNull()
 	}
 	
-    func isDirty() -> Bool {
-        var dirty = false
-        for field in fields {
-            if isDirty(field.name) {
-                dirty = true
-            }
-        }
-        return dirty
-    }
-
 	func isDirty(field: String) -> Bool {
 		guard let originalValue = originalValues[field] else {
 			return true

--- a/Spine/Resource.swift
+++ b/Spine/Resource.swift
@@ -152,6 +152,16 @@ public class Resource: NSObject, NSCoding {
 		originalValues[field] = value ?? NSNull()
 	}
 	
+    func isDirty() -> Bool {
+        var dirty = false
+        for field in fields {
+            if isDirty(field.name) {
+                dirty = true
+            }
+        }
+        return dirty
+    }
+
 	func isDirty(field: String) -> Bool {
 		guard let originalValue = originalValues[field] else {
 			return true
@@ -167,7 +177,7 @@ public class Resource: NSObject, NSCoding {
 			return originalValue !== valueForField(field)
 		}
 	}
-	
+    
 	func markField(field: String, asDirty dirty: Bool) {
 		if dirty {
 			originalValues[field] = nil

--- a/SpineTests/Fixtures/SingleFooNotAllAttributesSet.json
+++ b/SpineTests/Fixtures/SingleFooNotAllAttributesSet.json
@@ -1,0 +1,34 @@
+{
+	"data": {
+		"id": "1",
+		"type": "foos",
+		"attributes": {
+			"float-attribute": 5.5,
+			"boolean-attribute": true,
+			"nil-attribute": null,
+			"date-attribute": "1970-01-01T01:00:00.000+01:00"
+		},
+		"links": {
+			"self": "http://example.com/foos/1"
+		},
+		"relationships": {
+			"to-one-attribute": {
+				"links": {
+					"self": "http://example.com/foos/1/relationships/to-one-attribute",
+					"related": "http://example.com/bars/10"
+				},
+				"data": { "type": "bars", "id": "10" }
+			},
+			"to-many-attribute": {
+				"links": {
+					"self": "http://example.com/foos/1/relationships/to-many-attribute",
+					"related": "http://example.com/bars/11,12"
+				},
+				"data": [
+					{"type": "bars", "id": "11" },
+					{"type": "bars", "id": "12" }
+				]
+			}
+		}
+	}
+}

--- a/SpineTests/SerializingTests.swift
+++ b/SpineTests/SerializingTests.swift
@@ -351,4 +351,24 @@ class DeserializingTests: SerializerTests {
 			XCTFail("Deserialisation failed with error: \(error).")
 		}
 	}
+    
+    func testDeserializingAttributesNotSetInJSONWillNotChangeCurrentValues() {
+        let foo: Foo = Foo(id: "1")
+        foo.stringAttribute = "stringAttribute"
+        foo.integerAttribute = 10
+        foo.floatAttribute = 5.5
+        foo.booleanAttribute = true
+        foo.nilAttribute = "ShoudBeNilAfterDeserialization"
+
+        let fixture = JSONFixtureWithName("SingleFooNotAllAttributesSet")
+        
+        do {
+            try serializer.deserializeData(fixture.data, mappingTargets: [foo])
+            XCTAssertEqual(foo.stringAttribute, "stringAttribute", "Expected stringAttribute to be unchanged as attribut is not present in fixture")
+            XCTAssertEqual(foo.integerAttribute, 10, "Expected integerAttribute to be unchanged as attribut is not present in fixture")
+            XCTAssertNil(foo.nilAttribute, "Expected nilAttribute to be nil")
+        } catch let error as NSError {
+            XCTFail("Deserialisation failed with error: \(error).")
+        }
+    }
 }

--- a/SpineTests/SpineTests.swift
+++ b/SpineTests/SpineTests.swift
@@ -579,6 +579,39 @@ class SaveRelationshipsTests: SpineTests {
 			XCTAssertNil(error, "\(error)")
 		}
 	}
+    
+    func testItShouldPatchOnlyDirtyFields() {
+        var resourcePatched = false
+        
+        HTTPClient.handler = { request, payload in
+            XCTAssertEqual(request.HTTPMethod!, "PATCH", "HTTP method not as expected.")
+            if(request.URL! == NSURL(string: "http://example.com/foos/1")!) {
+                resourcePatched = true
+
+                let json = JSON(data: payload!)
+                XCTAssertEqual(json["data"]["id"].stringValue, self.foo.id!, "Serialized id is not equal.")
+                XCTAssertEqual(json["data"]["type"].stringValue, self.foo.resourceType, "Serialized type is not equal.")
+                XCTAssertEqual(json["data"]["attributes"]["string-attribute"].stringValue, self.foo.stringAttribute!, "Serialized string is not equal.")
+                XCTAssertNotNil(json["data"]["attributes"]["integer-attribute"].error, "Expected non dirty integer to be absent.")
+                XCTAssertNotNil(json["data"]["attributes"]["float-attribute"].error, "Expected non dirty float to be absent.")
+                XCTAssertNotNil(json["data"]["attributes"]["boolean-attribute"].error, "Expected non dirty boolean to be absent.")
+//                XCTAssertNotNil(json["data"]["attributes"]["nil-attribute"].error, "Expected non dirty nil to be absent.")
+                XCTAssertNotNil(json["data"]["attributes"]["date-attribute"].error, "Expected non dirty date to be absent.")
+            }
+            return (responseData: self.fixture.data, statusCode: 201, error: nil)
+        }
+        
+        foo.stringAttribute = "AttributeShouldBeDirtyNow"
+
+        let future = spine.save(foo)
+        let expectation = expectationWithDescription("")
+        assertFutureSuccess(future, expectation: expectation)
+        
+        waitForExpectationsWithTimeout(10) { error in
+            XCTAssertNil(error, "\(error)")
+            XCTAssertTrue(resourcePatched)
+        }
+    }
 }
 
 class PaginatingTests: SpineTests {


### PR DESCRIPTION
I fixed the issue that dirty fields checking was not enabled on updating a resource.