### PR TITLE
Add sorting based on custom attributes

### DIFF
--- a/Spine/Query.swift
+++ b/Spine/Query.swift
@@ -264,6 +264,22 @@ public struct Query<T: Resource> {
 			assertionFailure("Cannot add order on field \(fieldName) of resource \(T.resourceType). No such field has been configured.")
 		}
 	}
+
+    /// Sort in ascending order by the the given attribute. Previously added field take precedence over this field.
+    /// Won't check the presence of a field with this name.
+    ///
+    /// - parameter fieldName: The name of the field which to order by.
+    public mutating func addCustomAscendingOrder(_ attribute: String) {
+        sortDescriptors.append(NSSortDescriptor(key: attribute, ascending: true))
+    }
+
+    /// Sort in descending order by the the given attribute. Previously added field take precedence over this property.
+    /// Won't check the presence of a field with this name.
+    ///
+    /// - parameter property: The name of the field which to order by.
+    public mutating func addCustomDescendingOrder(_ attribute: String) {
+        sortDescriptors.append(NSSortDescriptor(key: attribute, ascending: false))
+    }
 	
 	
 	// MARK: Pagination

--- a/Spine/Query.swift
+++ b/Spine/Query.swift
@@ -120,7 +120,7 @@ public struct Query<T: Resource> {
 	/// - parameter fieldName: The name of the field to filter on.
 	/// - parameter value:     The value to check for.
 	/// - parameter type:      The comparison operator to use
-	mutating func addPredicateWithField(_ fieldName: String, value: Any, type: NSComparisonPredicate.Operator) {
+	public mutating func addPredicateWithField(_ fieldName: String, value: Any, type: NSComparisonPredicate.Operator) {
 		if let field = T.fields.filter({ $0.name == fieldName }).first {
 			addPredicateWithKey(field.name, value: value, type: type)
 		} else {
@@ -134,7 +134,7 @@ public struct Query<T: Resource> {
 	/// - parameter key:   The key of the field to filter on.
 	/// - parameter value: The value to check for.
 	/// - parameter type:  The comparison operator to use
-	mutating func addPredicateWithKey(_ key: String, value: Any, type: NSComparisonPredicate.Operator) {
+	public mutating func addPredicateWithKey(_ key: String, value: Any, type: NSComparisonPredicate.Operator) {
 		let predicate = NSComparisonPredicate(
 				leftExpression: NSExpression(forKeyPath: key),
 				rightExpression: NSExpression(forConstantValue: value),

--- a/Spine/Routing.swift
+++ b/Spine/Routing.swift
@@ -157,7 +157,7 @@ open class JSONAPIRouter: Router {
 		if !query.sortDescriptors.isEmpty {
 			let descriptorStrings = query.sortDescriptors.map { descriptor -> String in
 				let field = T.field(named: descriptor.key!)
-				let key = self.keyFormatter.format(field!)
+                let key = field != nil ? self.keyFormatter.format(field!) : descriptor.key!
 				if descriptor.ascending {
 					return key
 				} else {


### PR DESCRIPTION
As stated in the JSONAPI documentation:

> Note: Although recommended, sort fields do not necessarily need to correspond to resource attribute and association names.

it is not required that sort fields are a valid resource field. I added `addCustomAscendingOrder` and `addCustomDescendingOrder` which don't fail if the provided attribute is not a valid field.

I also changed the router so that it does not fail if a custom value was provided.

I think this should be added to Spine as JSONAPI does not restrict us to have custom sort fields.