### PR TITLE
Make id and type readonly accessible to outside classes

### DIFF
--- a/Spine/Resource.swift
+++ b/Spine/Resource.swift
@@ -13,10 +13,10 @@ public typealias ResourceType = String
 /// A ResourceIdentifier uniquely identifies a resource that exists on the server.
 public struct ResourceIdentifier: Equatable {
 	/// The resource type.
-	var type: ResourceType
+	private(set) public var type: ResourceType
 	
 	/// The resource ID.
-	var id: String
+	private(set) public var id: String
 
 	/// Constructs a new ResourceIdentifier instance with given `type` and `id`.
 	init(type: ResourceType, id: String) {
@@ -32,7 +32,7 @@ public struct ResourceIdentifier: Equatable {
 	}
 
 	/// Returns a dictionary with "type" and "id" keys containing the type and id.
-	func toDictionary() -> NSDictionary {
+	public func toDictionary() -> NSDictionary {
 		return ["type": type, "id": id]
 	}
 }


### PR DESCRIPTION
Make the dictionary accessible too.

The rationale is to be able to make associations to related objects based on their id value w/o having to retrieve the whole object in an include.