### PR TITLE
Check if null values should be omitted

### DIFF
--- a/Spine/SerializeOperation.swift
+++ b/Spine/SerializeOperation.swift
@@ -135,20 +135,23 @@ class SerializeOperation: Operation {
 			serializedId = NSNull()
 		}
 		
-		let serializedRelationship = [
-			"data": [
-				"type": type,
-				"id": serializedId
-			]
-		]
-		
-		if serializedData["relationships"] == nil {
-			serializedData["relationships"] = [key: serializedRelationship]
-		} else {
-			var relationships = serializedData["relationships"] as! [String: Any]
-			relationships[key] = serializedRelationship
-			serializedData["relationships"] = relationships
-		}
+        if !options.contains(.OmitNullValues) || (serializedId as? String) != nil {
+        
+            let serializedRelationship = [
+                "data": [
+                    "type": type,
+                    "id": serializedId
+                ]
+            ]
+            
+            if serializedData["relationships"] == nil {
+                serializedData["relationships"] = [key: serializedRelationship]
+            } else {
+                var relationships = serializedData["relationships"] as! [String: Any]
+                relationships[key] = serializedRelationship
+                serializedData["relationships"] = relationships
+            }
+        }
 	}
 	
 	/// Adds the given resources as a to to-many relationship to the serialized data.


### PR DESCRIPTION
When we create a serialisation with _toOne_ relationship, even if we pass **.OmitNullValues** option, _addToOneRelationship_ functions doesn't count that option. It creates a relationship with **NULL** value.