### PR TITLE
Return nil when link data is nil

### DIFF
--- a/Spine/DeserializeOperation.swift
+++ b/Spine/DeserializeOperation.swift
@@ -261,6 +261,11 @@ class DeserializeOperation: Operation {
 		var resource: Resource? = nil
 		
 		if let linkData = serializedData["relationships"][key].dictionary {
+            
+            guard linkData["data"] != nil else {
+                return nil
+            }
+
 			let type = linkData["data"]?["type"].string ?? linkedType
 			
 			if let id = linkData["data"]?["id"].string {

--- a/Spine/SerializeOperation.swift
+++ b/Spine/SerializeOperation.swift
@@ -135,20 +135,23 @@ class SerializeOperation: Operation {
 			serializedId = NSNull()
 		}
 		
-		let serializedRelationship = [
-			"data": [
-				"type": type,
-				"id": serializedId
-			]
-		]
-		
-		if serializedData["relationships"] == nil {
-			serializedData["relationships"] = [key: serializedRelationship]
-		} else {
-			var relationships = serializedData["relationships"] as! [String: Any]
-			relationships[key] = serializedRelationship
-			serializedData["relationships"] = relationships
-		}
+        if !options.contains(.OmitNullValues) || (serializedId as? String) != nil {
+        
+            let serializedRelationship = [
+                "data": [
+                    "type": type,
+                    "id": serializedId
+                ]
+            ]
+            
+            if serializedData["relationships"] == nil {
+                serializedData["relationships"] = [key: serializedRelationship]
+            } else {
+                var relationships = serializedData["relationships"] as! [String: Any]
+                relationships[key] = serializedRelationship
+                serializedData["relationships"] = relationships
+            }
+        }
 	}
 	
 	/// Adds the given resources as a to to-many relationship to the serialized data.


### PR DESCRIPTION
In _**fileprivate func extractToOneRelationship(_ key: String, from serializedData: JSON, linkedType: ResourceType) -> Resource?**_ function if _**linkData["data"]**_ is _**nil**_, then _**type**_ becomes equal to _**linkedType**_.
In next lines if _**resourceFactory.dispense()**_ or _**resourceFactory.instantiate()**_ thrown an error on _**type**_ value, then they will crash on _**linkedType**_ in _**catch**_ block.

